### PR TITLE
fix heredoc pattern

### DIFF
--- a/syntax/rcshell.vim
+++ b/syntax/rcshell.vim
@@ -100,8 +100,8 @@ syn cluster rcRedirect  contains=rcRedir,rcHereDoc
 syn match   rcRedir     "[<>]\v(\[\d+\=?\d*])?\ze([^{]|$)"  skipwhite nextgroup=@rcArgument contains=rcNumber
 syn match   rcRedir     ">>"                                skipwhite nextgroup=@rcArgument
 
-syn region  rcHereDoc   matchgroup=rcOperator    start="<<\(\[[0-9]\+\]\)\=\s*\z([^'> ]\+\)"   end="^\z1$" contains=rcVar
-syn region  rcHereDoc   matchgroup=rcOperator    start="<<\(\[[0-9]\+\]\)\=\s*\'\z([^']\+\)'" end="^\z1$"
+syn region  rcHereDoc   matchgroup=rcOperator    start="<\@<!<<\(\[[0-9]\+\]\)\=\s*\z([^'<> ]\+\)"   end="^\z1$" contains=rcVar
+syn region  rcHereDoc   matchgroup=rcOperator    start="<\@<!<<\(\[[0-9]\+\]\)\=\s*\'\z([^']\+\)'" end="^\z1$"
 " Todo: hero document in compound block
 
 "Compound Commands

--- a/syntax/rcshell.vim
+++ b/syntax/rcshell.vim
@@ -100,11 +100,9 @@ syn cluster rcRedirect  contains=rcRedir,rcHereDoc
 syn match   rcRedir     "[<>]\v(\[\d+\=?\d*])?\ze([^{]|$)"  skipwhite nextgroup=@rcArgument contains=rcNumber
 syn match   rcRedir     ">>"                                skipwhite nextgroup=@rcArgument
 
-syn region  rcHereDoc   matchgroup=rcOperator    start="<<\z([^<> ]\+\)"   end="^\z1$" contains=rcVar
-syn region  rcHereDoc   matchgroup=rcOperator    start="<<'\z(.*\)'" end="^\z1$"
-" Todo: what's with ^'s in here docs?
-" Todo: <<'>' >output or <<' 'EOF >output still doesn't get highlighted
-" correct, but I guess peopel are unlikely to write such scripts.
+syn region  rcHereDoc   matchgroup=rcOperator    start="<<\(\[[0-9]\+\]\)\=\s*\z([^'> ]\+\)"   end="^\z1$" contains=rcVar
+syn region  rcHereDoc   matchgroup=rcOperator    start="<<\(\[[0-9]\+\]\)\=\s*\'\z([^']\+\)'" end="^\z1$"
+" Todo: hero document in compound block
 
 "Compound Commands
 """"""""""""""""""


### PR DESCRIPTION
- support heredoc with file description

- support space between `<<` and EOF marker

    Although [plan9 rc manual][0] does not mention that
    space is allowed between `<<` and EOF marker,
    Byron Rakitzis' implementation does allow space.
    I have not checked other implementations (plan9, plan9port, 9base, etc.).

Besides, `<` is removed from disallowed characters in the pattern for the EOF marker. Some other popular shells support herestring `<<<`, so it is necessary to exclude `<` when matching `<<` for heredoc. However, rc shell does not support herestring.

close #3

[0]: http://doc.cat-v.org/plan_9/4th_edition/papers/rc